### PR TITLE
Guard oversized reference tracing with size limits and override

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,9 @@ export const TRACE_COLOR_BUCKET_STEP = 8;
 export const TRACE_DEFAULT_MAX_COLORS = 8;
 export const TRACE_MAX_COLORS_MIN = 1;
 export const TRACE_MAX_COLORS_MAX = 64;
+export const TRACE_CANVAS_MAX_DIMENSION = 4096;
+export const TRACE_CANVAS_MAX_PIXELS = 4_000_000;
+export const TRACE_CANVAS_OVERRIDE_STORAGE_KEY = 'pss.traceCanvasOversize';
 
 export const BYTES_PER_NUMBER = 8;
 export const PIXEL_RECORD_BYTES = BYTES_PER_NUMBER * 3;


### PR DESCRIPTION
### Motivation
- Prevent creating extremely large trace canvases that can consume lots of memory or crash the app when tracing large references.
- Provide immediate feedback to the user when a trace is blocked due to size.
- Allow power users to opt-in to bypass the guard when they know their environment can handle larger canvases.

### Description
- Added `TRACE_CANVAS_MAX_DIMENSION`, `TRACE_CANVAS_MAX_PIXELS`, and `TRACE_CANVAS_OVERRIDE_STORAGE_KEY` to `src/constants.ts`.
- Implemented `allowOversizedTraceCanvas()` and a size check in `buildTraceCanvas` in `src/renderer/services/referenceTrace.ts` to compute `width`, `height`, and `pixelCount` and return `null` if limits are exceeded unless the localStorage override is set.
- When the guard triggers the code now shows a user alert (when `window` is available) and emits a `console.warn` with diagnostic details to confirm the guard was hit.
- No other trace behavior was changed; canvas creation proceeds as before when sizes are within limits or the override is enabled.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964561ace148325978a51e0a32e4587)