### PR TITLE
Default layout: hide minimap + narrow toolbar

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1814,7 +1814,7 @@ const App = () => {
             <MinimapPanel />
           </div>
         ) : (
-          <div className="app__minimap-launch">
+          <div className="app__minimap-launch panel panel--collapsed">
             <button type="button" className="panel__toggle" onClick={() => setMinimapCollapsed(false)}>
               Minimap
             </button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -531,6 +531,8 @@ body {
   position: absolute;
   bottom: 16px;
   right: 16px;
+  pointer-events: auto;
+  z-index: 3;
 }
 
 .panel__section h2 {


### PR DESCRIPTION
- Hide minimap by default (show a small launcher button)
- Reduce toolbar width and stack tool groups vertically

Fixes initial load layout to prioritize canvas space.