### PR TITLE
Sync canvas edits into sampled tiles

### DIFF
--- a/src/renderer/canvas/ViewportCanvas.tsx
+++ b/src/renderer/canvas/ViewportCanvas.tsx
@@ -756,6 +756,14 @@ const ViewportCanvas = () => {
           blockCacheRef.current.set(key, rebuilt);
         }
       }
+      if (dirtyAll || dirtyBlocks.length > 0) {
+        useTileMapStore
+          .getState()
+          .refreshCanvasSourcedTiles(
+            dirtyAll,
+            dirtyBlocks.map((block) => ({ row: block.row, col: block.col }))
+          );
+      }
 
       const selectionState = useSelectionStore.getState();
       const selectionDirty = selectionState.consumeDirtyBlocks();

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -9,6 +9,7 @@ type TileSetPayload = {
     id: string;
     name?: string;
     pixels: number[];
+    source?: { kind: 'canvas'; x: number; y: number };
   }>;
 };
 

--- a/src/renderer/tools/tileSamplerTool.ts
+++ b/src/renderer/tools/tileSamplerTool.ts
@@ -91,7 +91,7 @@ export class TileSamplerTool implements Tool {
       startIndex = 0;
     }
 
-    const tilesToAdd: Array<{ name?: string; pixels: number[] }> = [];
+    const tilesToAdd: Array<{ name?: string; pixels: number[]; source?: { kind: 'canvas'; x: number; y: number } }> = [];
     for (let ty = bounds.minTileY; ty <= bounds.maxTileY; ty += 1) {
       for (let tx = bounds.minTileX; tx <= bounds.maxTileX; tx += 1) {
         const tilePixels: number[] = [];
@@ -102,7 +102,7 @@ export class TileSamplerTool implements Tool {
             tilePixels.push(pixelStore.getPixelComposite(startX + x, startY + y));
           }
         }
-        tilesToAdd.push({ pixels: tilePixels });
+        tilesToAdd.push({ pixels: tilePixels, source: { kind: 'canvas', x: startX, y: startY } });
       }
     }
 

--- a/tests/tileCanvasSync.test.ts
+++ b/tests/tileCanvasSync.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePixelStore } from '@/state/pixelStore';
+import { useTileMapStore } from '@/state/tileMapStore';
+
+describe('tile canvas sync', () => {
+  beforeEach(() => {
+    usePixelStore.getState().clear();
+    useTileMapStore.getState().clear();
+  });
+
+  it('updates canvas-sourced tiles when pixels change', () => {
+    const tileStore = useTileMapStore.getState();
+    const tileSetId = tileStore.addTileSet({
+      name: 'Test Set',
+      tileWidth: 2,
+      tileHeight: 2,
+      tiles: [
+        {
+          pixels: [0, 0, 0, 0],
+          source: { kind: 'canvas', x: 0, y: 0 },
+        },
+      ],
+    });
+
+    usePixelStore.getState().setPixel(0, 0, 3);
+    usePixelStore.getState().setPixel(1, 0, 4);
+    usePixelStore.getState().setPixel(0, 1, 5);
+    usePixelStore.getState().setPixel(1, 1, 6);
+    const dirty = usePixelStore.getState().consumeDirtyBlocks();
+    tileStore.refreshCanvasSourcedTiles(
+      dirty.dirtyAll,
+      dirty.blocks.map((block) => ({ row: block.row, col: block.col }))
+    );
+
+    const updatedTileSet = useTileMapStore.getState().tileSets.find((set) => set.id === tileSetId);
+    expect(updatedTileSet).toBeTruthy();
+    expect(updatedTileSet?.tiles[0]?.pixels).toEqual([3, 4, 5, 6]);
+  });
+});
+


### PR DESCRIPTION
Closes #40.

- Tile sampler stores the canvas origin for each sampled tile.
- When pixel blocks are dirtied, tiles sourced from the canvas are re-sampled so TileBar and tile map overlays stay in sync.
