### PR TITLE
Fix TMX export for Tiled

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run build:main && npm run build:renderer",
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:e2e": "npm run build:main && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 concurrently -k \"vite\" \"wait-on http://localhost:5173 && playwright test\"",
     "make": "electron-forge make"

--- a/src/renderer/services/tileMapExport.ts
+++ b/src/renderer/services/tileMapExport.ts
@@ -60,7 +60,7 @@ const buildTileAtlas = async (
     throw new Error('Unable to export tile atlas.');
   }
   const buffer = new Uint8Array(await blob.arrayBuffer());
-  return { buffer, columns, width, height };
+  return { buffer, columns, rows, width, height };
 };
 
 export const exportTileMapRegion = async (bounds: TileBounds) => {
@@ -136,12 +136,14 @@ export const exportTileMapRegion = async (bounds: TileBounds) => {
   for (let row = 0; row < mapHeight; row += 1) {
     const start = row * mapWidth;
     const rowValues = gids.slice(start, start + mapWidth).join(',');
-    dataRows.push(rowValues);
+    // Tiled's CSV parser expects comma-separated values; a newline alone is not a delimiter.
+    // Add a comma between each row so "...,<newline>..." doesn't become a corrupt token.
+    dataRows.push(row === mapHeight - 1 ? rowValues : `${rowValues},`);
   }
 
   const tmx = `<?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="${mapWidth}" height="${mapHeight}" tilewidth="${tileSet.tileWidth}" tileheight="${tileSet.tileHeight}" infinite="0">
-  <tileset firstgid="1" name="tiles" tilewidth="${tileSet.tileWidth}" tileheight="${tileSet.tileHeight}" tilecount="${usedTileIndices.length}" columns="${atlas.columns}">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="${mapWidth}" height="${mapHeight}" tilewidth="${tileSet.tileWidth}" tileheight="${tileSet.tileHeight}" infinite="0" nextlayerid="2" nextobjectid="1">
+  <tileset firstgid="1" name="tiles" tilewidth="${tileSet.tileWidth}" tileheight="${tileSet.tileHeight}" tilecount="${atlas.columns * atlas.rows}" columns="${atlas.columns}">
     <image source="tiles.png" width="${atlas.width}" height="${atlas.height}"/>
   </tileset>
   <layer id="1" name="Tile Layer 1" width="${mapWidth}" height="${mapHeight}">


### PR DESCRIPTION
Fixes #43.\n\n- Emit CSV rows with trailing commas so Tiled parses layer data correctly\n- Correct tileset tilecount to match atlas grid\n- Make 
> pixel-splash-studio@0.9.0 test
> vitest run


 RUN  v1.6.1 /var/home/longjoel/Documents/Projects/pixel-splash-studio

 ✓ tests/toolController.test.ts  (2 tests) 4ms
 ✓ tests/layerVisibilityStore.test.ts  (3 tests) 4ms
 ✓ tests/canvasStore.test.ts  (2 tests) 3ms
 ✓ tests/viewport.test.ts  (1 test) 3ms
 ✓ tests/pixelLayers.test.ts  (2 tests) 4ms
 ✓ tests/selectionLassoTool.test.ts  (2 tests) 5ms
 ✓ tests/tileCanvasSync.test.ts  (1 test) 7ms
 ✓ tests/tilePenTool.test.ts  (1 test) 7ms
 ✓ tests/scrollSelectionTool.test.ts  (2 tests) 21ms
 ✓ tests/deepCopySelection.test.ts  (3 tests) 31ms
 ✓ tests/sprayTool.test.ts  (1 test) 40ms
 ✓ tests/fillBucketToolGradient.test.ts  (2 tests) 9ms
 ✓ tests/bookmarkStore.test.ts  (4 tests) 7ms

 Test Files  13 passed (13)
      Tests  26 passed (26)
   Start at  15:55:04
   Duration  760ms (transform 1.24s, setup 0ms, collect 2.41s, tests 145ms, environment 4ms, prepare 1.55s) run in non-watch mode by default